### PR TITLE
CI: add emulator test with API health check and Python exec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
             echo "::endgroup::"
             echo "::group::API health check"
             adb forward tcp:8765 tcp:8765
-            curl -sf --retry 15 --retry-delay 2 --retry-connrefused http://127.0.0.1:8765/health
+            curl -sf --retry 15 --retry-delay 2 --retry-all-errors http://127.0.0.1:8765/health
             echo ""
             echo "::endgroup::"
             echo "::group::Python exec test"


### PR DESCRIPTION
## Summary
- Add emulator-based CI job that installs the debug APK, launches the activity, and verifies the app process stays alive
- Extend emulator test with API health check (`/health`) and Python execution test (`/shell/exec`) over adb port forwarding
- Fix Ruff lint failures by removing unused imports
- Fix shell compatibility issues for `reactivecircus/android-emulator-runner@v2` (per-line `sh -c` execution)

## Test plan
- [x] `lint` job passes (Ruff check)
- [x] `smoke-test` jobs pass (Python 3.10 + 3.11)
- [x] `android-apk-build` job passes (debug APK built)
- [x] `emulator-test` job passes — APK installs, activity launches, process alive
- [x] Health check succeeds: `{"status":"ok","service":"local","python":"offline"}`
- [x] Python exec test succeeds: `{"status": "ok", "code": 0, "output": "(3, 11)\n"}`
- [x] Both `logcat.txt` and `shell_result.json` uploaded as artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)